### PR TITLE
feat: upbit-data 토픽을 구독하는 handleCoinEvent 메서드 구현

### DIFF
--- a/coin/src/main/java/com/tradingtrends/coin/infrastructure/messaging/UpbitWebSocketService.java
+++ b/coin/src/main/java/com/tradingtrends/coin/infrastructure/messaging/UpbitWebSocketService.java
@@ -80,6 +80,9 @@ public class UpbitWebSocketService {
                 return;
             }
 
+            // 종목 개수
+            log.info("원화 마켓 종목 개수: {}", marketCodes.size());
+
             // 웹소켓 연결 후 업비트 서버에 요청 보내기
             String ticketValue = UUID.randomUUID().toString();
             String message = "[{\"ticket\":\"" + ticketValue + "\"},{\"type\":\"ticker\",\"codes\":" + marketCodes.toString() + "},{\"format\":\"DEFAULT\"}]";
@@ -96,13 +99,13 @@ public class UpbitWebSocketService {
             // 추출된 데이터를 Kafka 토픽으로 전송
             kafkaTemplate.send(CoinTopic.UPBIT_DATA.getTopic(), parsedData)
                     .thenAccept(result -> {
-                        log.info("Message sent successfully: {}", parsedData); // 메세지 전송 성공 로그
+//                        log.info("Message sent successfully: {}", parsedData); // 메세지 전송 성공 로그
                     })
                     .exceptionally(ex -> {
-                        log.error("Message failed to send: {}", ex.getMessage()); // 메세지 전송 실패 로그
+//                        log.error("Message failed to send: {}", ex.getMessage()); // 메세지 전송 실패 로그
                         return null;
                     });
-            log.info("Received binary message converted to text: {}", payload); // 변환된 메세지 로그
+//            log.info("Received binary message converted to text: {}", payload); // 변환된 메세지 로그
         }
 
         // 웹소켓에서 받은 메세지 데이터를 파싱 후 필요한 필드 추출하는 메서드

--- a/market/src/main/java/com/tradingtrends/market/MarketApplication.java
+++ b/market/src/main/java/com/tradingtrends/market/MarketApplication.java
@@ -1,4 +1,4 @@
-package com.tradingtrends.coin;
+package com.tradingtrends.market;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/market/src/main/java/com/tradingtrends/market/infrastructure/messaging/MarketDataConsumer.java
+++ b/market/src/main/java/com/tradingtrends/market/infrastructure/messaging/MarketDataConsumer.java
@@ -1,0 +1,22 @@
+package com.tradingtrends.market.infrastructure.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketDataConsumer {
+    @KafkaListener(topics = "upbit-data", groupId = "market-group")
+    public void handleCoinEvent(Map<String, Object> message) {
+        try {
+            log.info("Consumed message: {}", message);
+        } catch (Exception e) {
+            log.error("Failed to consume message: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/market/src/test/java/com/tradingtrends/market/MarketApplicationTests.java
+++ b/market/src/test/java/com/tradingtrends/market/MarketApplicationTests.java
@@ -1,4 +1,4 @@
-package com.tradingtrends.coin;
+package com.tradingtrends.market;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## Description

- Kafka에서 upbit-data 토픽을 구독하는 handleCoinEvent 메서드 구현하여 컨슈머 기능 확인
- 원화 마켓 종목 개수 로그 추가
- 메시지 전송 성공/실패 로그 주석 처리

해결된 문제: # (이슈)

## Type of change

- [x] 새로운 기능 (기존 기능을 깨뜨리지 않는 새로운 기능 추가)

## How Has This Been Tested?

변경 사항을 검증하기 위해 실행한 테스트를 설명하세요. 재현할 수 있는 방법을 제공해주세요. 또한 테스트 구성에 대한 세부 사항을 나열해주세요.

- market service 시작 후에 localhost:8080 접속하여 확인