### PR TITLE
feat: 한국투자증권 실시간 데이터 kafka 적재

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ out/
 
 ### data ###
 /postgres_data/**
+
+### dotenv ###
+stock/.env.dev
+.env
+stock/.env.dev

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,6 @@ out/
 /postgres_data/**
 
 ### dotenv ###
-stock/.env.dev
 .env
-stock/.env.dev
+.env.dev
+.env.**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,87 +22,139 @@ services:
     ports:
       - "26379:6379"  # 바인딩할 포트:내부 포트
 
-  zookeeper:
+  coin-zookeeper:
     image: confluentinc/cp-zookeeper:latest
-    container_name: tt-zookeeper
+    container_name: coin-zookeeper
     ports:
       - "2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_SERVER_ID: 1
 
-  kafka1:
+  stock-zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: stock-zookeeper
+    ports:
+      - "2182:2181"  # 주식 서비스용 주키퍼는 포트를 2182로 사용
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 2
+
+  coin-kafka1:
     image: confluentinc/cp-kafka:latest
-    container_name: tt-kafka1
+    container_name: coin-kafka1
     ports:
       - "9092:9092"
       - "29092:29092"
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_ZOOKEEPER_CONNECT: "coin-zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://coin-kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
     depends_on:
-      - zookeeper
+      - coin-zookeeper
 
-  kafka2:
+  coin-kafka2:
     image: confluentinc/cp-kafka:latest
-    container_name: tt-kafka2
+    container_name: coin-kafka2
     ports:
       - "9093:9093"
       - "29093:29093"
     environment:
       KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093,DOCKER://host.docker.internal:29093
+      KAFKA_ZOOKEEPER_CONNECT: "coin-zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://coin-kafka2:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093,DOCKER://host.docker.internal:29093
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
     depends_on:
-      - zookeeper
+      - coin-zookeeper
 
-  kafka3:
+  coin-kafka3:
     image: confluentinc/cp-kafka:latest
-    container_name: tt-kafka3
+    container_name: coin-kafka3
     ports:
       - "9094:9094"
       - "29094:29094"
     environment:
       KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094,DOCKER://host.docker.internal:29094
+      KAFKA_ZOOKEEPER_CONNECT: "coin-zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://coin-kafka3:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094,DOCKER://host.docker.internal:29094
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
     depends_on:
-      - zookeeper
+      - coin-zookeeper
 
-#  kafdrop:
-#    image: obsidiandynamics/kafdrop
-#    restart: "no"
-#    ports:
-#      - "9000:9000"
-#    environment:
-#      KAFKA_BROKER_CONNECT: "kafka1:19092"
-#    depends_on:
-#      - kafka1
-#      - kafka2
-#      - kafka3
+  stock-kafka1:
+    image: confluentinc/cp-kafka:latest
+    container_name: stock-kafka1
+    ports:
+      - "9095:9095"
+      - "29095:29095"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "stock-zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://stock-kafka1:19095,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9095,DOCKER://host.docker.internal:29095
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+    depends_on:
+      - stock-zookeeper
+
+  stock-kafka2:
+    image: confluentinc/cp-kafka:latest
+    container_name: stock-kafka2
+    ports:
+      - "9096:9096"
+      - "29096:29096"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: "stock-zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://stock-kafka2:19096,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9096,DOCKER://host.docker.internal:29096
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+    depends_on:
+      - stock-zookeeper
+
+  stock-kafka3:
+    image: confluentinc/cp-kafka:latest
+    container_name: stock-kafka3
+    ports:
+      - "9097:9097"
+      - "29097:29097"
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: "stock-zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://stock-kafka3:19097,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9097,DOCKER://host.docker.internal:29097
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+    depends_on:
+      - stock-zookeeper
+
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     container_name: tt-kafka-ui
     depends_on:
-      - kafka1
-      - kafka2
-      - kafka3
+      - coin-kafka1
+      - coin-kafka2
+      - coin-kafka3
+      - stock-kafka1
+      - stock-kafka2
+      - stock-kafka3
     ports:
       - "8080:8080"
     environment:
-      KAFKA_CLUSTERS_0_NAME: local
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka1:29092,kafka2:29093,kafka3:29094
-      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_NAME: coin
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: coin-kafka1:29092,coin-kafka2:29093,coin-kafka3:29094
+      KAFKA_CLUSTERS_1_NAME: stock
+      KAFKA_CLUSTERS_1_BOOTSTRAPSERVERS: stock-kafka1:29095,stock-kafka2:29096,stock-kafka3:29097
+      KAFKA_CLUSTERS_0_ZOOKEEPER: coin-zookeeper:2181
+      KAFKA_CLUSTERS_1_ZOOKEEPER: stock-zookeeper:2181
 
   zipkin:
     image: openzipkin/zipkin:latest

--- a/docs/client/config/http-client.env.json
+++ b/docs/client/config/http-client.env.json
@@ -1,6 +1,7 @@
 {
   "local": {
     "gateway": "http://localhost:19091",
+    "stock": "http://localhost:19095",
     "coin": "http://localhost:19096",
     "market": "http://localhost:19100"
   }

--- a/docs/client/market.http
+++ b/docs/client/market.http
@@ -9,3 +9,32 @@ POST http://localhost:19096/disconnect-websocket
 Content-Type: application/json
 
 ###
+
+# @name 한국투자증권 WebSocket approvalKey 발급 API
+GET http://localhost:19095/get-approval-key
+Content-Type: application/json
+
+###
+
+## 삼성전자 : 005930
+
+# @name Stock WebSocket 연결 API
+POST http://localhost:19095/connect-websocket
+Accept: application/json
+Content-Type: application/json
+approval_key: 05eeb26d-3e91-48b0-b13f-62ffd053efaf
+custtype: P
+tr_type: 1
+
+{
+  "tr_id": "H0STCNT0",
+  "tr_key": "005930"
+}
+
+###
+
+# @name Stock WebSocket 해제 API
+POST http://localhost:19095/disconnect-websocket
+Content-Type: application/json
+
+###

--- a/stock/build.gradle
+++ b/stock/build.gradle
@@ -28,6 +28,15 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	runtimeOnly 'org.postgresql:postgresql'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+
 	//Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/stock/src/main/java/com/tradingtrends/stock/StockApplication.java
+++ b/stock/src/main/java/com/tradingtrends/stock/StockApplication.java
@@ -1,5 +1,6 @@
 package com.tradingtrends.stock;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class StockApplication {
 
 	public static void main(String[] args) {
+
+		// .env 파일 로드
+		Dotenv dotenv = Dotenv.configure().filename(".env.dev").load();
+		System.setProperty("APP_KEY", dotenv.get("APP_KEY"));
+		System.setProperty("APP_SECRET", dotenv.get("APP_SECRET"));
+
 		SpringApplication.run(StockApplication.class, args);
 	}
 

--- a/stock/src/main/java/com/tradingtrends/stock/application/dto/ApprovalRequest.java
+++ b/stock/src/main/java/com/tradingtrends/stock/application/dto/ApprovalRequest.java
@@ -1,0 +1,9 @@
+package com.tradingtrends.stock.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ApprovalRequest {
+    private String tr_id;  // 거래 ID
+    private String tr_key; // 종목번호
+}

--- a/stock/src/main/java/com/tradingtrends/stock/application/service/StockWebSocketKeyService.java
+++ b/stock/src/main/java/com/tradingtrends/stock/application/service/StockWebSocketKeyService.java
@@ -1,0 +1,29 @@
+package com.tradingtrends.stock.application.service;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class StockWebSocketKeyService {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String API_URL = "https://openapi.koreainvestment.com:9443/oauth2/Approval";
+
+    public String getApprovalKey(String appKey, String appSecret) {
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("grant_type", "client_credentials");
+        requestBody.put("appkey", appKey);
+        requestBody.put("secretkey", appSecret);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(API_URL, HttpMethod.POST, requestEntity, Map.class);
+        return (String) response.getBody().get("approval_key");
+    }
+}

--- a/stock/src/main/java/com/tradingtrends/stock/infrastructure/StockTopic.java
+++ b/stock/src/main/java/com/tradingtrends/stock/infrastructure/StockTopic.java
@@ -1,0 +1,15 @@
+package com.tradingtrends.stock.infrastructure;
+
+public enum StockTopic {
+    STOCK_DATA("stock-data");
+
+    private final String topic;
+
+    StockTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+}

--- a/stock/src/main/java/com/tradingtrends/stock/infrastructure/config/AppConfig.java
+++ b/stock/src/main/java/com/tradingtrends/stock/infrastructure/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.tradingtrends.stock.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/stock/src/main/java/com/tradingtrends/stock/infrastructure/config/KafkaProducerConfig.java
+++ b/stock/src/main/java/com/tradingtrends/stock/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,43 @@
+package com.tradingtrends.stock.infrastructure.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public Map<String, Object> producerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        // idempotence(중복 방지)와 함께 사용할 때 메시지의 정확한 순서 보장과 데이터 손실 방지를 위해 중요합니다.
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 메세지 중복 전송 방지
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1); // 프로듀서가 단일 연결을 통해 동시에 전송 가능한 요청의 최대 수, default : 5
+
+        return props;
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigs());
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/stock/src/main/java/com/tradingtrends/stock/infrastructure/config/KafkaTopicConfig.java
+++ b/stock/src/main/java/com/tradingtrends/stock/infrastructure/config/KafkaTopicConfig.java
@@ -1,0 +1,30 @@
+package com.tradingtrends.stock.infrastructure.config;
+
+import com.tradingtrends.stock.infrastructure.StockTopic;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin(){
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        return new KafkaAdmin(configs);
+    }
+
+    @Bean
+    public NewTopic topic(){
+        return new NewTopic(StockTopic.STOCK_DATA.getTopic(), 3, (short) 2);
+    }
+}

--- a/stock/src/main/java/com/tradingtrends/stock/infrastructure/messaging/StockWebSocketService.java
+++ b/stock/src/main/java/com/tradingtrends/stock/infrastructure/messaging/StockWebSocketService.java
@@ -1,0 +1,199 @@
+package com.tradingtrends.stock.infrastructure.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tradingtrends.stock.application.dto.ApprovalRequest;
+import com.tradingtrends.stock.infrastructure.StockTopic;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockWebSocketService {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private WebSocketSession webSocketSession;
+
+    // WebSocket 연결
+    public void connectWebSocket(String approvalKey, String custType, String trType, ApprovalRequest approvalRequest) {
+        if (webSocketSession != null && webSocketSession.isOpen()) {
+            log.info("WebSocket is already connected.");
+            return;
+        }
+
+        StandardWebSocketClient client = new StandardWebSocketClient();
+        client.doHandshake(new StockWebSocketHandler(approvalKey, custType, trType, approvalRequest), "ws://ops.koreainvestment.com:21000");
+        log.info("WebSocket connection initiated.");
+    }
+
+    // WebSocket 연결 해제
+    public void disconnectWebSocket() throws IOException {
+        if (webSocketSession != null && webSocketSession.isOpen()) {
+            try {
+                webSocketSession.close();
+                log.info("WebSocket connection closed.");
+            } catch (Exception e) {
+                log.error("Failed to close WebSocket: {}", e.getMessage());
+            }
+        } else {
+            log.info("No active WebSocket connection to close.");
+        }
+    }
+
+    // WebSocket 핸들러 클래스 정의
+    private class StockWebSocketHandler extends TextWebSocketHandler {
+        private final String approvalKey;
+        private final String custType;
+        private final String trType;
+        private final ApprovalRequest approvalRequest;
+
+        public StockWebSocketHandler(String approvalKey, String custType, String trType, ApprovalRequest approvalRequest) {
+            this.approvalKey = approvalKey;
+            this.custType = custType;
+            this.trType = trType;
+            this.approvalRequest = approvalRequest;
+        }
+
+        @Override
+        public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+            log.info("WebSocket connected");
+
+            // 웹소켓 세션을 저장
+            webSocketSession = session;
+
+            // 요청 데이터 생성
+            String sendData = createRequestData(approvalKey, custType, trType, approvalRequest);
+
+            // WebSocket 서버로 메시지 전송
+            session.sendMessage(new TextMessage(sendData));
+            log.info("Sent message: {}", sendData);
+        }
+
+        // 요청 데이터를 JSON 형태로 생성
+        private String createRequestData(String approvalKey, String custType, String trType, ApprovalRequest approvalRequest) {
+            return "{\n" +
+                    "  \"header\": {\n" +
+                    "    \"approval_key\": \"" + approvalKey + "\",\n" +
+                    "    \"custtype\": \"" + custType + "\",\n" +
+                    "    \"tr_type\": \"" + trType + "\",\n" +
+                    "    \"content-type\": \"utf-8\"\n" +
+                    "  },\n" +
+                    "  \"body\": {\n" +
+                    "    \"input\": {\n" +
+                    "      \"tr_id\": \"" + approvalRequest.getTr_id() + "\",\n" +
+                    "      \"tr_key\": \"" + approvalRequest.getTr_key() + "\"\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}";
+        }
+
+        // WebSocket 서버에서 메시지 수신 처리
+        @Override
+        protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+            String payload = message.getPayload();
+            log.info("Received message: {}", payload);
+
+            // PINGPONG 또는 SUBSCRIBE SUCCESS 메세지 필터링
+            // 해당 메시지를 특별한 처리 없이 로그에 기록만 하고 실제 데이터 처리 로직을 실행하지 않고 반환
+            if (payload.contains("PINGPONG") || payload.contains("SUBSCRIBE SUCCESS")) {
+                log.info("PINGPONG 또는 SUBSCRIBE SUCCESS 메세지입니다.");
+                return;
+            }
+
+            // 실시간 데이터 파싱 및 JSON 변환
+            String jsonData = parseStockData(payload);
+
+            if (jsonData != null) {
+                // 수신된 JSON 데이터를 Kafka로 전송
+                try {
+                    // Kafka로 메시지 전송 및 파티션과 오프셋 로깅 처리
+                    CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(StockTopic.STOCK_DATA.getTopic(), jsonData);
+
+                    // 비동기적으로 Kafka 전송 결과 처리
+                    future.whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            // 메시지 전송 성공, 파티션 및 오프셋 로깅
+                            log.info("Message sent successfully to partition=[{}], offset=[{}]",
+                                    result.getRecordMetadata().partition(),
+                                    result.getRecordMetadata().offset());
+                        } else {
+                            // 메시지 전송 실패
+                            log.error("Message failed to send due to: {}", ex.getMessage());
+                        }
+                    });
+                } catch (Exception e) {
+                    log.error("Failed to send message to Kafka: {}", e.getMessage());
+                }
+            }
+        }
+
+        // 실시간 데이터를 파싱하여 필요한 정보만 추출 후 JSON 형식으로 변환
+        private String parseStockData(String rawData) {
+            try {
+                // "|" 문자로 데이터를 분리
+                // 수신된 데이터는 여러 부분으로 구성되어 있으므로 "|"를 기준으로 나눔
+                String[] parts = rawData.split("\\|");
+
+                // 분리된 데이터가 예상한 부분 수보다 적으면 잘못된 데이터 형식으로 간주하고 로그 출력
+                if (parts.length < 4) {
+                    log.error("Invalid data format.");
+                    return null;
+                }
+
+                // 주식 체결 데이터 추출
+                // parts[3]에 체결 데이터가 포함되어 있어서 이 걸 "^"로 다시 분리하여 세부 데이터를 추출
+                String[] tradeData = parts[3].split("\\^");
+
+                // 체결 데이터가 충분하지 않을 경우 로그에 에러 메시지를 남기고 종료
+                if (tradeData.length < 6) {
+                    log.error("Insufficient trade data.");
+                    return null;
+                }
+
+                // 체결 데이터에서 종목코드, 현재가, 전일 대비 가격, 전일 대비율 추출
+                String stockCode = tradeData[0]; // 종목코드
+                String currentPrice = tradeData[2]; // 현재가
+                String priceChange = tradeData[4]; // 전일 대비 가격
+                String changeRate = tradeData[5]; // 전일 대비율
+
+                // 추출된 데이터 로그
+                log.info("종목코드: {}, 현재가: {}, 전일 대비 가격: {}, 전일 대비율: {}%",
+                        stockCode, currentPrice, priceChange, changeRate);
+
+                // JSON 형식으로 변환할 Map 생성
+                Map<String, Object> stockDataMap = new HashMap<>();
+                stockDataMap.put("stockCode", stockCode);
+                stockDataMap.put("currentPrice", currentPrice);
+                stockDataMap.put("priceChange", priceChange);
+                stockDataMap.put("changeRate", changeRate);
+
+                // Map을 JSON 문자열로 변환
+                return objectMapper.writeValueAsString(stockDataMap);
+            } catch (Exception e) {
+                // 파싱 중 오류
+                log.error("Error parsing stock data: {}", e.getMessage());
+                return null;
+            }
+        }
+
+        // WebSocket 연결 종료 처리
+        @Override
+        public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+            log.info("WebSocket connection closed: sessionId={}, status={}", session.getId(), status);
+            webSocketSession = null;
+        }
+    }
+}

--- a/stock/src/main/java/com/tradingtrends/stock/presentation/controller/WebsocketController.java
+++ b/stock/src/main/java/com/tradingtrends/stock/presentation/controller/WebsocketController.java
@@ -1,11 +1,12 @@
 package com.tradingtrends.stock.presentation.controller;
 
+import com.tradingtrends.stock.application.dto.ApprovalRequest;
 import com.tradingtrends.stock.application.service.StockWebSocketKeyService;
+import com.tradingtrends.stock.infrastructure.messaging.StockWebSocketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class WebsocketController {
     private String appSecret;
 
     private final StockWebSocketKeyService stockWebSocketKeyService;
+    private final StockWebSocketService stockWebSocketService;
 
     // 실시간 (웹소켓) 접속키 발급 API
     @GetMapping("/get-approval-key")
@@ -25,5 +27,24 @@ public class WebsocketController {
         String approvalKey = stockWebSocketKeyService.getApprovalKey(appKey, appSecret);
 
         return ResponseEntity.ok("Approval Key: " + approvalKey);
+    }
+
+    // WebSocket 연결 API
+    @PostMapping("/connect-websocket")
+    public ResponseEntity<String> connectWebSocket(
+            @RequestHeader("approval_key") String approvalKey,
+            @RequestHeader("custtype") String custType,
+            @RequestHeader("tr_type") String trType,
+            @RequestBody ApprovalRequest approvalRequest
+    ) {
+        stockWebSocketService.connectWebSocket(approvalKey, custType, trType, approvalRequest);
+        return ResponseEntity.ok("WebSocket connected with approval key: " + approvalKey);
+    }
+
+    // WebSocket 연결 해제 API
+    @PostMapping("/disconnect-websocket")
+    public ResponseEntity<String> disconnectWebSocket() throws Exception {
+        stockWebSocketService.disconnectWebSocket();
+        return ResponseEntity.ok("WebSocket disconnected.");
     }
 }

--- a/stock/src/main/java/com/tradingtrends/stock/presentation/controller/WebsocketController.java
+++ b/stock/src/main/java/com/tradingtrends/stock/presentation/controller/WebsocketController.java
@@ -1,0 +1,29 @@
+package com.tradingtrends.stock.presentation.controller;
+
+import com.tradingtrends.stock.application.service.StockWebSocketKeyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class WebsocketController {
+    @Value("${stock-api.appkey}")
+    private String appKey;
+
+    @Value("${stock-api.appsecret}")
+    private String appSecret;
+
+    private final StockWebSocketKeyService stockWebSocketKeyService;
+
+    // 실시간 (웹소켓) 접속키 발급 API
+    @GetMapping("/get-approval-key")
+    public ResponseEntity<String> getApprovalKey() {
+        // Approval Key 발급
+        String approvalKey = stockWebSocketKeyService.getApprovalKey(appKey, appSecret);
+
+        return ResponseEntity.ok("Approval Key: " + approvalKey);
+    }
+}

--- a/stock/src/main/resources/application.yml
+++ b/stock/src/main/resources/application.yml
@@ -5,9 +5,25 @@ spring:
   application:
     name: stock
 
+  kafka:
+    bootstrap-servers: localhost:9095,localhost:9096,localhost:9097
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer # Kafka 메세지의 키를 문자열로 역직렬화
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer # Kafka 메세지의 값을 JSON으로 역직렬화
+      auto-offset-reset: latest # 메세지 읽는 순서
+      properties:
+        spring.json.trusted.packages: '*'
+        allow.auto.create.topic: false # 코드에서 토픽 자동 생성을 막음
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer # Kafka 메시지의 키를 문자열로 직렬화
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer # Kafka 메세지의 값을 JSON으로 직렬화
+
 eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
 
-
+# 한국투자증권 API 인증 정보
+stock-api:
+  appkey: ${APP_KEY}
+  appsecret: ${APP_SECRET}


### PR DESCRIPTION
## Description

- 한국투자증권 api 받아오기 위한 설정
- 한국투자증권 실시간 웹소켓 접속키 발급 API 구현
  - .env 파일 추가
- 한국투자증권 실시간 데이터 kafka 적재
  - 삼성전자만 적재 (이후, 코스피 200으로 변경)
- 테스트용 http client 추가

해결된 문제: # (이슈)

## Type of change

관련되지 않은 옵션은 삭제하세요.

- [ ] 버그 수정 (기존 기능을 깨뜨리지 않는 문제 해결)
- [x] 새로운 기능 (기존 기능을 깨뜨리지 않는 새로운 기능 추가)
- [ ] 호환성 깨짐 (기존 기능이 예상대로 동작하지 않게 되는 수정 또는 기능 추가)
- [ ] 이 변경 사항은 문서 업데이트가 필요합니다.

## How Has This Been Tested?

변경 사항을 검증하기 위해 실행한 테스트를 설명하세요. 재현할 수 있는 방법을 제공해주세요. 또한 테스트 구성에 대한 세부 사항을 나열해주세요.

- .env 파일 로컬에 추가 후 테스트용 http client에서 api 호출로 테스트

## CheckList:

- [x] 내 코드는 이 프로젝트의 스타일 가이드라인을 따릅니다.
- [x] 나는 내 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 대해 주석을 추가했습니다.
- [x] 문서에도 해당하는 변경 사항을 작성했습니다.
- [x] 내 변경 사항은 새로운 경고를 발생시키지 않습니다.
- [x] 내 수정 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 내 변경 사항으로 기존 유닛 테스트들이 모두 통과됩니다.
- [x] 종속된 변경 사항들은 병합되었고 하위 모듈에서 배포되었습니다.
