### PR TITLE
fix : DartDisclosureService 공시 검색 유일성 위배 해결

### DIFF
--- a/batch/src/main/java/com/tradingtrends/batch/application/service/DartDisclosureService.java
+++ b/batch/src/main/java/com/tradingtrends/batch/application/service/DartDisclosureService.java
@@ -62,7 +62,17 @@ public class DartDisclosureService {
             JsonNode resultNode = rootNode.path("list");
 
             for (JsonNode item : resultNode) {
+
+                String rceptNo = item.path("rcept_no").asText();
+
+                // 이미 존재하는 rcept_no는 스킵
+                if (disclosureRepository.existsByRceptNo(rceptNo)) {
+                    log.info("Already exists rcept_no: " + rceptNo);
+                    continue;  // 이미 존재하는 경우 다음 항목으로 넘어감
+                }
+
                 Disclosure entity = new Disclosure();
+
                 entity.setRceptNo(item.path("rcept_no").asText());
                 entity.setCorpName(item.path("corp_name").asText());
                 entity.setCorpCode(item.path("corp_code").asText());

--- a/batch/src/main/java/com/tradingtrends/batch/domain/repository/DisclosureRepository.java
+++ b/batch/src/main/java/com/tradingtrends/batch/domain/repository/DisclosureRepository.java
@@ -19,4 +19,5 @@ public interface DisclosureRepository extends JpaRepository<Disclosure, UUID> {
     @Query("SELECT d.rceptNo FROM Disclosure d WHERE d.loadDt BETWEEN :startDate AND :endDate")
     List<String> findRceptNoByLoadDtBetween(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
+    boolean existsByRceptNo(String rceptNo);
 }


### PR DESCRIPTION
## Description

fix : DartDisclosureService 공시 검색 유일성 위배 해결

해결된 문제: # (이슈)

 recpt_no 유일성 위배 시 500에러가 아닌 무시하고 다음 항목으로 넘어감

## Type of change

관련되지 않은 옵션은 삭제하세요.

- [ ] 버그 수정 (기존 기능을 깨뜨리지 않는 문제 해결)
- [ ] 새로운 기능 (기존 기능을 깨뜨리지 않는 새로운 기능 추가)
- [ ] 호환성 깨짐 (기존 기능이 예상대로 동작하지 않게 되는 수정 또는 기능 추가)
- [ ] 이 변경 사항은 문서 업데이트가 필요합니다.

## How Has This Been Tested?

변경 사항을 검증하기 위해 실행한 테스트를 설명하세요. 재현할 수 있는 방법을 제공해주세요. 또한 테스트 구성에 대한 세부 사항을 나열해주세요.

- [ ] 테스트 A
- [ ] 테스트 B

**테스트 구성**:
* 펌웨어 버전:
* 하드웨어:
* 툴체인:
* SDK:

## CheckList:

- [ ] 내 코드는 이 프로젝트의 스타일 가이드라인을 따릅니다.
- [ ] 나는 내 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 대해 주석을 추가했습니다.
- [ ] 문서에도 해당하는 변경 사항을 작성했습니다.
- [ ] 내 변경 사항은 새로운 경고를 발생시키지 않습니다.
- [ ] 내 수정 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [ ] 내 변경 사항으로 기존 유닛 테스트들이 모두 통과됩니다.
- [ ] 종속된 변경 사항들은 병합되었고 하위 모듈에서 배포되었습니다.
